### PR TITLE
Replaced jQuery with bootstrap.native

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Installation
     ```bash
     yarn
     yarn add @symfony/webpack-encore sass-loader node-sass lodash.throttle -D
-    yarn add bootstrap glightbox @fortawesome/fontawesome-svg-core @fortawesome/free-brands-svg-icons @fortawesome/free-regular-svg-icons @fortawesome/free-solid-svg-icons
+    yarn add bootstrap bootstrap.native glightbox axios form-serialize @fortawesome/fontawesome-svg-core @fortawesome/free-brands-svg-icons @fortawesome/free-regular-svg-icons @fortawesome/free-solid-svg-icons
     ```
    
 4. Import bootstrap-theme config in the main webpack file


### PR DESCRIPTION
Missing packages:

```
These dependencies were not found:

* axios in ./themes/BootstrapTheme/assets/js/index.js, ./themes/tps/assets/js/sylius-api-toggle.js and 4 others
* bootstrap.native/dist/bootstrap-native-v4 in ./themes/BootstrapTheme/assets/js/index.js
* form-serialize in ./themes/BootstrapTheme/assets/js/sylius-add-to-cart.js
```