### PR TITLE
Fix wrong loading-overlay object appending

### DIFF
--- a/assets/js/sylius-loadable-forms.js
+++ b/assets/js/sylius-loadable-forms.js
@@ -13,7 +13,7 @@ const SyliusLoadableForms = function SyliusLoadableForms() {
   const overlay = document.querySelector('[data-js-loading-overlay]');
 
   document.querySelectorAll('form.loadable').forEach((form) => {
-    form.appendChild(overlay);
+    form.appendChild(overlay.cloneNode(true));
     form.addEventListener('submit', () => {
       form.classList.add('loading');
     });


### PR DESCRIPTION
When you iterate over array of DOM nodes, appendChild to each node wont work, because only one reference of append source is declared. You need to clone every instance of node to make it work.
You are appending the same element over and over. You need to call document.createElement each time you wish to have a new element or you can clone it.