### PR TITLE
Fix wrong loading-overlay back button behaviour

### DIFF
--- a/assets/js/sylius-loadable-forms.js
+++ b/assets/js/sylius-loadable-forms.js
@@ -17,6 +17,11 @@ const SyliusLoadableForms = function SyliusLoadableForms() {
     form.addEventListener('submit', () => {
       form.classList.add('loading');
     });
+    window.addEventListener('pageshow', () => {
+      if (event.persisted) {
+        form.classList.remove('loading');
+      }
+    });
   });
 };
 


### PR DESCRIPTION
When user click submit, loading overlay is shown, but it doesn't hide on back button event, preventing interaction. This fix solve that. Tested on Firefox and Chrome.