### PR TITLE
Improve provinceContainer selectability

### DIFF
--- a/SyliusShopBundle/views/Common/Form/_address.html.twig
+++ b/SyliusShopBundle/views/Common/Form/_address.html.twig
@@ -7,7 +7,7 @@
 
 {% include '@SyliusShop/Common/Form/_countryCode.html.twig' with {'form': form.countryCode} %}
 
-<div class="form-group province-container" data-url="{{ path('sylius_shop_ajax_render_province_form') }}">
+<div class="form-group province-container" data-url="{{ path('sylius_shop_ajax_render_province_form') }}" data-parent="{{ form.countryCode.vars.id }}">
     {% if form.provinceCode is defined %}
         {{ form_row(form.provinceCode, {'attr': {'class': ''}}) }}
     {% elseif form.provinceName is defined %}

--- a/assets/js/sylius-province-field.js
+++ b/assets/js/sylius-province-field.js
@@ -24,7 +24,7 @@ const SyliusProvinceField = function SyliusProvinceField() {
   countrySelect.forEach((countrySelectItem) => {
     countrySelectItem.addEventListener('change', (event) => {
       const select = event.currentTarget;
-      const provinceContainer = select.closest('.form-group').nextElementSibling;
+      const provinceContainer = document.querySelector('[data-parent="' + select.id + '"]');
 
       const provinceSelectFieldName = select.getAttribute('name').replace('country', 'province');
       const provinceInputFieldName = select.getAttribute('name').replace('countryCode', 'provinceName');


### PR DESCRIPTION
RIght now, when countrySelect search for provinceSelect, it uses .nextElementSibling selector. This aproach is markup dependant, and it breaks when provinceSelect is not an inmediate countrySelect sibling. This solution solves that.