### PR TITLE
Change sylius-api-toggle event from keyup to input

### DIFF
--- a/assets/js/sylius-api-toggle.js
+++ b/assets/js/sylius-api-toggle.js
@@ -17,7 +17,7 @@ const SyliusApiToggle = (el) => {
   const url = element.getAttribute('data-js-login-check-email-url');
   const toggleableElement = document.querySelector('[data-js-login="form"]');
 
-  element.addEventListener('keyup', throttle((e) => {
+  element.addEventListener('input', throttle((e) => {
     toggleableElement.classList.add('d-none');
 
     if (e.target.value.length > 3) {


### PR DESCRIPTION
When email is pasted directly from browser the event is not fired. Changing it to input will fire it no matter what. Tested on Firefox and Chrome.