### PR TITLE
Fixed sorting path while sorting by position

### DIFF
--- a/SyliusShopBundle/views/Product/Index/_sorting.html.twig
+++ b/SyliusShopBundle/views/Product/Index/_sorting.html.twig
@@ -5,7 +5,7 @@
 
 {% set criteria = app.request.query.get('criteria', {}) %}
 
-{% set default_path = path(route, route_parameters|merge({'criteria': criteria})) %}
+{% set default_path = path(route, route_parameters|merge({'sorting': null, 'criteria': criteria})) %}
 {% set from_a_to_z_path = path(route, route_parameters|merge({'sorting': {'name': 'asc'}, 'criteria': criteria})) %}
 {% set from_z_to_a_path = path(route, route_parameters|merge({'sorting': {'name': 'desc'}, 'criteria': criteria})) %}
 {% set oldest_first_path = path(route, route_parameters|merge({'sorting': {'createdAt': 'asc'}, 'criteria': criteria})) %}


### PR DESCRIPTION
**Description**
On products page, you can't change back to default sorting (sort by position) after choosing another sorting method.

**Steps to reproduce**
1. Go to: {localhost}/taxons/{slug}/
2. Click on Sort by from A to Z
3. Try to sort it again by position.

It won't work, it will still be sorted from A to Z.

**Possible solution**
https://github.com/Sylius/Sylius/pull/10053