### PR TITLE
fix broken carousel when products count is less than 4 and a odd number

### DIFF
--- a/SyliusShopBundle/views/Homepage/_carousel.html.twig
+++ b/SyliusShopBundle/views/Homepage/_carousel.html.twig
@@ -8,7 +8,7 @@
                     <div class="col-6">
                         {% include '@SyliusShop/Product/_box.html.twig' %}
                     </div>
-            {% if loop.index % 2 == 0 %}
+            {% if loop.index % 2 == 0 or loop.last %}
                 </div>
             </div>
             {% endif %}


### PR DESCRIPTION
When products count is less than 4 and a odd number the carousel include the newsletter and the about blocks in the last item which break the html structure.