### PR TITLE
remove version 4 suffix from bootstrap-native import

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -11,7 +11,7 @@
 
 import GLightbox from 'glightbox';
 import axios from 'axios';
-import 'bootstrap.native/dist/bootstrap-native-v4';
+import 'bootstrap.native/dist/bootstrap-native';
 
 import SyliusRating from './sylius-rating';
 import SyliusToggle from './sylius-toggle';


### PR DESCRIPTION
Don't define a bootstrap native version. 

fixes Sylius/BootstrapTheme#40