### PR TITLE
Issue-#10 - Fix: Collapse Javascript when the taxons is not exist

### DIFF
--- a/SyliusShopBundle/views/Taxon/_horizontalMenu.html.twig
+++ b/SyliusShopBundle/views/Taxon/_horizontalMenu.html.twig
@@ -22,21 +22,21 @@
 
 {% import _self as macros %}
 
-{% if taxons|length > 0 %}
-    <nav class="navbar navbar-expand-lg">
-        <div class="collapse navbar-collapse justify-content-center" id="mainNavbar">
+<nav class="navbar navbar-expand-lg">
+    <div class="collapse navbar-collapse justify-content-center" id="mainNavbar">
+        {% if taxons|length > 0 %}
             <div class="navbar-nav py-1">
                 {% for taxon in taxons %}
                     {{ macros.item(taxon) }}
                 {% endfor %}
             </div>
-            <div class="d-md-none py-3 border-top">
-                {{ sonata_block_render_event('sylius.shop.layout.before_security_widget') }}
+        {% endif %}
+        <div class="d-md-none py-3 border-top">
+            {{ sonata_block_render_event('sylius.shop.layout.before_security_widget') }}
 
-                {{ render(controller('sylius.controller.shop.security_widget:renderAction')) }}
+            {{ render(controller('sylius.controller.shop.security_widget:renderAction')) }}
 
-                {{ sonata_block_render_event('sylius.shop.layout.after_security_widget') }}
-            </div>
+            {{ sonata_block_render_event('sylius.shop.layout.after_security_widget') }}
         </div>
-    </nav>
-{% endif %}
+    </div>
+</nav>

--- a/SyliusShopBundle/views/_header.html.twig
+++ b/SyliusShopBundle/views/_header.html.twig
@@ -17,7 +17,7 @@
             {{ render(url('sylius_shop_partial_cart_summary', {'template': '@SyliusShop/Cart/_widget.html.twig'})) }}
         </div>
     </div>
-    <div class="col-auto d-lg-none ml-2">
+    <div class="{{ 'col-auto ml-2 ' ~ ((taxons|length > 0) ? 'd-lg-none' : 'd-md-none') }}">
         <div class="navbar-light">
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNavbar">
                 <span class="navbar-toggler-icon"></span>

--- a/SyliusShopBundle/views/layout.html.twig
+++ b/SyliusShopBundle/views/layout.html.twig
@@ -42,7 +42,7 @@
     <div class="mb-2">
         <div class="container">
             <header class="my-4">
-                {% include '@SyliusShop/_header.html.twig' %}
+                {{ render(url('sylius_shop_partial_taxon_index_by_code', {'code': 'category', 'template': '@SyliusShop/_header.html.twig'})) }}
 
                 {{ sonata_block_render_event('sylius.shop.layout.after_header') }}
             </header>


### PR DESCRIPTION
Issue link: https://github.com/Sylius/BootstrapTheme/issues/10

This fix is only for current version (0.1.1) because the templates have changed a lot.