### PR TITLE
Not loading taxons menu when there are no taxons

### DIFF
--- a/SyliusShopBundle/views/_header.html.twig
+++ b/SyliusShopBundle/views/_header.html.twig
@@ -4,6 +4,7 @@
 
             {{ sylius_template_event('sylius.shop.layout.header.grid') }}
 
+            {% if taxons is defined and taxons|length > 0 %}
             <div class="col-auto d-lg-none ml-2">
                 <div class="navbar-light">
                     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNavbar">
@@ -11,6 +12,7 @@
                     </button>
                 </div>
             </div>
+            {% endif %}
         </div>
     </header>
 </div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/BootstrapTheme/pull/56
| License         | MIT

Fixes the WIP problem with the collapsing of the menu when there are no taxons.
