### PR TITLE
Fix typo in address form

### DIFF
--- a/SyliusShopBundle/views/Checkout/Address/_form.html.twig
+++ b/SyliusShopBundle/views/Checkout/Address/_form.html.twig
@@ -10,7 +10,7 @@
             {% if form.customer is defined %}
                 {% include '@SyliusShop/Common/Form/_login.html.twig' with {'form': form.customer} %}
             {% endif %}
-            {% include '@SyliusShop/Common/Form/_address.html.twig' with {'form': form.billingAddress, 'order': order, 'type', 'billing'} %}
+            {% include '@SyliusShop/Common/Form/_address.html.twig' with {'form': form.billingAddress, 'order': order, 'type': 'billing'} %}
             {{ form_row(form.differentShippingAddress, sylius_test_form_attribute('different-shipping-address')|sylius_merge_recursive({'attr': {'data-js-toggle': '[data-js-address-book="sylius-shipping-address"]'}})) }}
 
             {{ sylius_template_event('sylius.shop.checkout.address.billing_address_form', {'order': order}) }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #65 
| License         | MIT

I had this error in twig `A hash key must be followed by a colon (:). Unexpected token "punctuation" of value "," ("punctuation" expected with value ":").`

It's regression after #65 merged.
