### PR TITLE
Update from Sylius default theme

### DIFF
--- a/SyliusShopBundle/views/Product/Show/_variants.html.twig
+++ b/SyliusShopBundle/views/Product/Show/_variants.html.twig
@@ -9,7 +9,7 @@
         </tr>
     </thead>
     <tbody>
-    {% for key, variant in product.variants %}
+    {% for key, variant in product.enabledVariants %}
         <tr>
             <td>
                 {{ variant.name }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

Since Sylius 1.8 a ProductVariant can be disabled. The product show page display all product variants, disabled included.

This PR display only product variant enabled.





